### PR TITLE
datly proxy response even in case of error

### DIFF
--- a/service/session/stater.go
+++ b/service/session/stater.go
@@ -113,9 +113,9 @@ func (s *Session) handleComponentpOutputType(ctx context.Context, dest interface
 	s.Options = *s.Indirect(true, stateOptions...)
 	destValue, err := s.operate(ctx, s, s.component)
 	s.Options = sessionOpt
+	reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(destValue).Elem())
 	if err != nil {
 		return err
 	}
-	reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(destValue).Elem())
 	return nil
 }

--- a/service/session/stater.go
+++ b/service/session/stater.go
@@ -113,7 +113,11 @@ func (s *Session) handleComponentpOutputType(ctx context.Context, dest interface
 	s.Options = *s.Indirect(true, stateOptions...)
 	destValue, err := s.operate(ctx, s, s.component)
 	s.Options = sessionOpt
-	reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(destValue).Elem())
+
+	if destValue != nil {
+		reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(destValue).Elem())
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Datly proxy response is received even in case of error returned by the API.