### PR TITLE
handleComponentpOutputType nil pointer check added

### DIFF
--- a/service/session/stater.go
+++ b/service/session/stater.go
@@ -113,8 +113,7 @@ func (s *Session) handleComponentpOutputType(ctx context.Context, dest interface
 	s.Options = *s.Indirect(true, stateOptions...)
 	destValue, err := s.operate(ctx, s, s.component)
 	s.Options = sessionOpt
-
-	if destValue != nil {
+	if dest != nil && destValue != nil {
 		reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(destValue).Elem())
 	}
 


### PR DESCRIPTION
I observed panic while working with Proxy APIs Datly. 


Here is the stack trace.
`Panic occurred: reflect: call of reflect.Value.Elem on struct Value, Stack trace: goroutine 77467 [running]:
runtime/debug.Stack()
runtime/debug/stack.go:26 +0x5e
github.vianttech.com/viant/platform/pkg/platform/errorutils.PanicHandler({0x30cc670, 0xc00233c310}, {0x2661c40, 0xc002fafbc0}, 0xc002ae5078, 0xc002ae50a8)
github.vianttech.com/viant/platform/pkg/platform/errorutils/panichandler.go:21 +0x67
panic({0x265fe40?, 0xc001e7e060?})
runtime/panic.go:792 +0x132
reflect.Value.Elem({0x283f920?, 0xc0042645a0?, 0xc00208c3f0?})
reflect/value.go:1265 +0x190
github.com/viant/datly/service/session.(*Session).handleComponentpOutputType(0xc002489180, {0x30cc670, 0xc00233c310}, {0x2661520, 0xc002fafe00}, {0xc00208c3f0?, 0x10?, 0x34?})
github.com/viant/datly@v0.20.6-0.20250710224149-9634038811f3/service/session/stater.go:118 +0x29e
github.com/viant/datly/service/session.(*Session).Bind(0xc002489180, {0x30cc670, 0xc00233c310}, {0x2661520, 0xc002fafe00}, {0xc0028ea1b8, 0x1, 0xc0021e64e0?})
github.com/viant/datly@v0.20.6-0.20250710224149-9634038811f3/service/session/stater.go:97 +0x1237
github.com/viant/xdatly/handler/state.Service.Bind(...)
github.com/viant/xdatly/handler@v0.0.0-20250418144853-029d9a05ae20/state/state.go:34
...`