### PR TITLE
fixing concurrent map iteration error

### DIFF
--- a/view/state.go
+++ b/view/state.go
@@ -161,7 +161,7 @@ func NewState() *State {
 // Init initializes each Statelet
 func (s *State) Init(aView *View) {
 	s.RWMutex.Lock()
-	s.RWMutex.Unlock()
+	defer s.RWMutex.Unlock()
 	for _, selector := range s.Views {
 		selector.Init(aView)
 	}


### PR DESCRIPTION
fix for concurrent map iteration error observed when multiple patch requests were issued for the same endpoint simultaneously.