### PR TITLE
Expose metrics and add request trace correlation

### DIFF
--- a/gateway/route.go
+++ b/gateway/route.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/viant/afs/url"
+	"github.com/viant/datly/internal/requesttrace"
 	"github.com/viant/datly/gateway/router"
 	"github.com/viant/datly/repository"
 	"github.com/viant/datly/repository/contract"
@@ -53,6 +54,7 @@ func (r *Route) Handle(res http.ResponseWriter, req *http.Request) int {
 	}
 	execContext := exec.NewContext(req.Method, req.RequestURI, req.Header, r.Version)
 	ctx = vcontext.WithValue(ctx, exec.ContextKey, execContext)
+	ctx = requesttrace.Ensure(ctx, execContext.TraceID)
 	req = req.WithContext(ctx)
 	var onDone func(time.Time, ...interface{}) int64 = nil
 	var start time.Time

--- a/gateway/route_metric.go
+++ b/gateway/route_metric.go
@@ -27,6 +27,34 @@ func (r *Router) NewMetricRoute(URI string) *Route {
 	}
 }
 
+func (r *Router) NewGlobalMetricRoutes(URI string) []*Route {
+	if !strings.HasSuffix(URI, "/") {
+		URI += "/"
+	}
+	handler := func(ctx context.Context, response http.ResponseWriter, req *http.Request) {
+		r.handleMetrics(response, req, URI)
+	}
+	paths := []string{
+		URI + "operations",
+		URI + "operation/{name}",
+		URI + "operation/{name}/cumulative/{metric}",
+		URI + "operation/{name}/recent/{metric}",
+		URI + "operation/{name}/recent",
+		URI + "counters",
+		URI + "counter/{name}",
+	}
+	routes := make([]*Route, 0, len(paths))
+	for _, pathURI := range paths {
+		routes = append(routes, &Route{
+			Path:    contract.NewPath(http.MethodGet, pathURI),
+			Handler: handler,
+			Config:  r.config.Logging,
+			Version: r.config.Version,
+		})
+	}
+	return routes
+}
+
 func (r *Router) handleMetrics(writer http.ResponseWriter, req *http.Request, URI string) {
 	gmetric.NewHandler(URI, r.metrics).ServeHTTP(writer, req)
 }

--- a/gateway/route_metric_provider.go
+++ b/gateway/route_metric_provider.go
@@ -1,0 +1,26 @@
+package gateway
+
+import (
+	"github.com/viant/gmetric/counter"
+	"github.com/viant/gmetric/counter/base"
+)
+
+const (
+	routeRequestMetric   = "Request"
+	routeSuccessMetric   = "Success"
+	routeErrorMetric     = "Error"
+	routeStatus2xxMetric = "status:2xx"
+	routeStatus4xxMetric = "status:4xx"
+	routeStatus5xxMetric = "status:5xx"
+)
+
+func newRouteMetricProvider() counter.Provider {
+	return base.NewProvider(
+		routeRequestMetric,
+		routeSuccessMetric,
+		routeErrorMetric,
+		routeStatus2xxMetric,
+		routeStatus4xxMetric,
+		routeStatus5xxMetric,
+	)
+}

--- a/gateway/route_metric_provider_test.go
+++ b/gateway/route_metric_provider_test.go
@@ -1,0 +1,36 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/viant/gmetric"
+)
+
+func TestRouteMetricProvider_ExportsRouteCounters(t *testing.T) {
+	metrics := gmetric.New()
+	counter := metrics.MultiOperationCounter("steward/metadata", "steward.metadata.signalPerformance.request", "signal performance request", time.Millisecond, time.Minute, 2, newRouteMetricProvider())
+
+	counter.IncrementValue(routeRequestMetric)
+	counter.IncrementValue(routeSuccessMetric)
+	counter.IncrementValue(routeStatus2xxMetric)
+	counter.IncrementValue(routeErrorMetric)
+	counter.IncrementValue(routeStatus4xxMetric)
+	counter.IncrementValue(routeStatus5xxMetric)
+
+	operation := metrics.LookupOperation("steward.metadata.signalPerformance.request")
+	require.NotNil(t, operation)
+
+	values := map[string]int64{}
+	for _, item := range operation.Counters {
+		values[item.Value] = item.Count
+	}
+
+	require.Equal(t, int64(1), values[routeRequestMetric])
+	require.Equal(t, int64(1), values[routeSuccessMetric])
+	require.Equal(t, int64(1), values[routeStatus2xxMetric])
+	require.Equal(t, int64(1), values[routeErrorMetric])
+	require.Equal(t, int64(1), values[routeStatus4xxMetric])
+	require.Equal(t, int64(1), values[routeStatus5xxMetric])
+}

--- a/gateway/route_metric_test.go
+++ b/gateway/route_metric_test.go
@@ -1,0 +1,23 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouterNewGlobalMetricRoutes(t *testing.T) {
+	router := &Router{config: &Config{}}
+
+	routes := router.NewGlobalMetricRoutes("/v1/api/meta/metric")
+
+	require.Len(t, routes, 7)
+	require.Equal(t, "/v1/api/meta/metric/operations", routes[0].Path.URI)
+	require.Equal(t, "/v1/api/meta/metric/operation/{name}", routes[1].Path.URI)
+	require.Equal(t, "/v1/api/meta/metric/operation/{name}/cumulative/{metric}", routes[2].Path.URI)
+	require.Equal(t, "/v1/api/meta/metric/operation/{name}/recent/{metric}", routes[3].Path.URI)
+	require.Equal(t, "/v1/api/meta/metric/operation/{name}/recent", routes[4].Path.URI)
+	require.Equal(t, "/v1/api/meta/metric/counters", routes[5].Path.URI)
+	require.Equal(t, "/v1/api/meta/metric/counter/{name}", routes[6].Path.URI)
+	require.Nil(t, routes[0].ApiKeys)
+}

--- a/gateway/route_metrics.go
+++ b/gateway/route_metrics.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/viant/datly/internal/gmetricx"
 	dlogger "github.com/viant/datly/logger"
 	"github.com/viant/datly/repository"
-	gprovider "github.com/viant/gmetric/provider"
+	"github.com/viant/gmetric"
 )
 
 // ensureRouteCounter pre-registers a per-route counter and returns a logger-compatible adapter.
@@ -45,13 +46,10 @@ func (r *Router) ensureRouteCounter(ctx context.Context, prov *repository.Provid
 	}
 	metricName = strings.ReplaceAll(metricName, "/", ".")
 
-	cnt := r.metrics.LookupOperation(metricName)
-	if cnt == nil {
-		// Title: human-friendly
-		title := v.Name + " request"
-		cnt = r.metrics.MultiOperationCounter(pkg, metricName, title, time.Millisecond, time.Minute, 2, gprovider.NewBasic())
-	}
-	return dlogger.NewCounter(cnt)
+	title := v.Name + " request"
+	return dlogger.NewCounter(gmetricx.NewCounter(r.metrics, metricName, func() *gmetric.Operation {
+		return r.metrics.MultiOperationCounter(pkg, metricName, title, time.Millisecond, time.Minute, 2, newRouteMetricProvider())
+	}))
 }
 
 // normalizeURI replaces path parameters like {id} with a constant token to limit cardinality.

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -432,6 +432,9 @@ func (r *Router) newMatcher(ctx context.Context) (*matcher.Matcher, []*contract.
 		routes,
 		r.NewConfigRoute(),
 	)
+	if strings.TrimSpace(r.config.Meta.MetricURI) != "" {
+		routes = append(routes, r.NewGlobalMetricRoutes(r.config.Meta.MetricURI)...)
+	}
 
 	matchables := make([]matcher.Matchable, 0, len(routes))
 	for _, route := range routes {

--- a/gateway/router/handler.go
+++ b/gateway/router/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/viant/afs/option"
 	acontent "github.com/viant/afs/option/content"
 	"github.com/viant/afs/url"
+	"github.com/viant/datly/internal/requesttrace"
 	"github.com/viant/datly/gateway/router/openapi"
 	"github.com/viant/datly/gateway/router/status"
 	"github.com/viant/datly/repository"
@@ -178,6 +179,7 @@ func (r *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	}
 	execContext := exec.NewContext(req.Method, req.RequestURI, req.Header, r.Version)
 	ctx = vcontext.WithValue(ctx, exec.ContextKey, execContext)
+	ctx = requesttrace.Ensure(ctx, execContext.TraceID)
 	req = req.WithContext(ctx)
 	r.HandleRequest(ctx, writer, req)
 	if execContext.StatusCode == 0 {

--- a/gateway/warmup/cache.go
+++ b/gateway/warmup/cache.go
@@ -3,6 +3,7 @@ package warmup
 import (
 	"context"
 	"fmt"
+	"github.com/viant/datly/internal/gmetricx"
 	"github.com/viant/datly/view"
 	"github.com/viant/datly/warmup"
 	"github.com/viant/gmetric"
@@ -269,7 +270,7 @@ func recordWarmupViewMetrics(aView *view.View, summary *viewSummary) {
 	}
 }
 
-func warmupMetricOperation(aView *view.View) *gmetric.Operation {
+func warmupMetricOperation(aView *view.View) *gmetricx.OperationRef {
 	if aView == nil {
 		return nil
 	}
@@ -278,18 +279,17 @@ func warmupMetricOperation(aView *view.View) *gmetric.Operation {
 		return nil
 	}
 	metricName := warmupMetricName(aView)
-	if counter := resource.Metrics.Service.LookupOperation(metricName); counter != nil {
-		return counter
-	}
 	pkg := warmupMetricPackage(aView)
 	title := aView.Name + " warmup"
-	return resource.Metrics.Service.MultiOperationCounter(pkg, metricName, title, time.Millisecond, time.Minute, warmupMetricRecentBuckets, base.NewProvider(
-		warmupRunOKKey,
-		warmupRunErrorKey,
-		warmupCasesCompletedKey,
-		warmupCasesFailedKey,
-		warmupRowsKey,
-	))
+	return gmetricx.NewOperationRef(resource.Metrics.Service, metricName, func() *gmetric.Operation {
+		return resource.Metrics.Service.MultiOperationCounter(pkg, metricName, title, time.Millisecond, time.Minute, warmupMetricRecentBuckets, base.NewProvider(
+			warmupRunOKKey,
+			warmupRunErrorKey,
+			warmupCasesCompletedKey,
+			warmupCasesFailedKey,
+			warmupRowsKey,
+		))
+	})
 }
 
 func warmupMetricName(aView *view.View) string {

--- a/internal/gmetricx/counter.go
+++ b/internal/gmetricx/counter.go
@@ -1,0 +1,120 @@
+package gmetricx
+
+import (
+	"sync"
+	"time"
+
+	"github.com/viant/datly/logger"
+	"github.com/viant/gmetric"
+	"github.com/viant/gmetric/counter"
+)
+
+var serviceLocks sync.Map
+
+type OperationRef struct {
+	service *gmetric.Service
+	name    string
+	create  func() *gmetric.Operation
+}
+
+type operationCounter struct {
+	ref *OperationRef
+}
+
+func NewCounter(service *gmetric.Service, name string, create func() *gmetric.Operation) logger.Counter {
+	return &operationCounter{
+		ref: NewOperationRef(service, name, create),
+	}
+}
+
+func NewOperationRef(service *gmetric.Service, name string, create func() *gmetric.Operation) *OperationRef {
+	return &OperationRef{
+		service: service,
+		name:    name,
+		create:  create,
+	}
+}
+
+func (c *operationCounter) Begin(started time.Time) counter.OnDone {
+	if c == nil || c.ref == nil {
+		return func(time.Time, ...interface{}) int64 { return 0 }
+	}
+	return c.ref.Begin(started)
+}
+
+func (c *operationCounter) DecrementValue(value interface{}) int64 {
+	if c == nil || c.ref == nil {
+		return 0
+	}
+	return c.ref.DecrementValue(value)
+}
+
+func (c *operationCounter) IncrementValue(value interface{}) int64 {
+	if c == nil || c.ref == nil {
+		return 0
+	}
+	return c.ref.IncrementValue(value)
+}
+
+func (r *OperationRef) Begin(started time.Time) counter.OnDone {
+	return func(end time.Time, values ...interface{}) int64 {
+		return withOperation(r, func(op *gmetric.Operation) int64 {
+			return op.Begin(started)(end, values...)
+		})
+	}
+}
+
+func (r *OperationRef) DecrementValue(value interface{}) int64 {
+	return withOperation(r, func(op *gmetric.Operation) int64 {
+		return op.DecrementValue(value)
+	})
+}
+
+func (r *OperationRef) IncrementValue(value interface{}) int64 {
+	return withOperation(r, func(op *gmetric.Operation) int64 {
+		return op.IncrementValue(value)
+	})
+}
+
+func (r *OperationRef) IncrementValueBy(value interface{}, delta int64) int64 {
+	return withOperation(r, func(op *gmetric.Operation) int64 {
+		return op.IncrementValueBy(value, delta)
+	})
+}
+
+func withOperation(ref *OperationRef, fn func(*gmetric.Operation) int64) int64 {
+	if ref == nil || ref.service == nil {
+		return 0
+	}
+	mux := serviceLock(ref.service)
+	mux.Lock()
+	defer mux.Unlock()
+
+	op := lookupOperationUnlocked(ref.service, ref.name)
+	if op == nil && ref.create != nil {
+		op = ref.create()
+	}
+	if op == nil {
+		return 0
+	}
+	return fn(op)
+}
+
+func serviceLock(service *gmetric.Service) *sync.Mutex {
+	if actual, ok := serviceLocks.Load(service); ok {
+		return actual.(*sync.Mutex)
+	}
+	mux := &sync.Mutex{}
+	actual, _ := serviceLocks.LoadOrStore(service, mux)
+	return actual.(*sync.Mutex)
+}
+
+func lookupOperationUnlocked(service *gmetric.Service, name string) *gmetric.Operation {
+	operations := service.OperationCounters()
+	for i := range operations {
+		if operations[i].Name == name {
+			return &operations[i]
+		}
+	}
+	return nil
+}

--- a/internal/gmetricx/service.go
+++ b/internal/gmetricx/service.go
@@ -1,0 +1,18 @@
+package gmetricx
+
+import "github.com/viant/gmetric"
+
+// LookupOperation returns a snapshot of the named operation under the gmetricx service lock.
+func LookupOperation(service *gmetric.Service, name string) *gmetric.Operation {
+	if service == nil {
+		return nil
+	}
+	mux := serviceLock(service)
+	mux.Lock()
+	defer mux.Unlock()
+	if op := lookupOperationUnlocked(service, name); op != nil {
+		snapshot := *op
+		return &snapshot
+	}
+	return nil
+}

--- a/internal/gmetricx/service_test.go
+++ b/internal/gmetricx/service_test.go
@@ -1,0 +1,65 @@
+package gmetricx
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/viant/datly/logger"
+	"github.com/viant/gmetric"
+	gprovider "github.com/viant/gmetric/provider"
+)
+
+func TestLookupOperationReturnsOperationSnapshot(t *testing.T) {
+	metrics := gmetric.New()
+	counterName := "steward.metadata.signalPerformance"
+	resolver := logger.NewCounter(NewCounter(metrics, counterName, func() *gmetric.Operation {
+		return metrics.MultiOperationCounter("steward/metadata", counterName, "signal performance", time.Millisecond, time.Minute, 2, gprovider.NewBasic())
+	}))
+	resolver.IncrementValue("pending")
+
+	operation := LookupOperation(metrics, counterName)
+	require.NotNil(t, operation)
+	require.Equal(t, counterName, operation.Name)
+	require.Equal(t, int64(1), operation.Counters[1].Count)
+}
+
+func TestNewCounterSurvivesOperationSliceGrowth(t *testing.T) {
+	metrics := gmetric.New()
+	counterName := "steward.metadata.signalPerformance"
+	resolver := logger.NewCounter(NewCounter(metrics, counterName, func() *gmetric.Operation {
+		return metrics.MultiOperationCounter("steward/metadata", counterName, "signal performance", time.Millisecond, time.Minute, 2, gprovider.NewBasic())
+	}))
+
+	resolver.IncrementValue("pending")
+
+	for i := 0; i < 32; i++ {
+		metrics.MultiOperationCounter("steward/metadata", fmt.Sprintf("%s.extra.%d", counterName, i), "extra", time.Millisecond, time.Minute, 2, gprovider.NewBasic())
+	}
+
+	resolver.IncrementValue("pending")
+
+	require.Equal(t, int64(2), metrics.LookupOperationCumulativeMetric(counterName, "pending"))
+}
+
+func TestNewCounterBeginSurvivesOperationSliceGrowth(t *testing.T) {
+	metrics := gmetric.New()
+	counterName := "steward.metadata.signalPerformance"
+	resolver := logger.NewCounter(NewCounter(metrics, counterName, func() *gmetric.Operation {
+		return metrics.MultiOperationCounter("steward/metadata", counterName, "signal performance", time.Millisecond, time.Minute, 2, gprovider.NewBasic())
+	}))
+
+	started := time.Now().Add(-10 * time.Millisecond)
+	onDone := resolver.Begin(started)
+
+	for i := 0; i < 32; i++ {
+		metrics.MultiOperationCounter("steward/metadata", fmt.Sprintf("%s.begin.extra.%d", counterName, i), "extra", time.Millisecond, time.Minute, 2, gprovider.NewBasic())
+	}
+
+	onDone(time.Now(), "pending")
+
+	require.Equal(t, int64(1), metrics.LookupOperationCumulativeMetric(counterName, "count"))
+	require.Equal(t, int64(1), metrics.LookupOperationCumulativeMetric(counterName, "pending"))
+	require.GreaterOrEqual(t, metrics.LookupOperationCumulativeMetric(counterName, "timeTaken"), int64(1))
+}

--- a/internal/requesttrace/context.go
+++ b/internal/requesttrace/context.go
@@ -1,0 +1,29 @@
+package requesttrace
+
+import "context"
+
+type contextKey struct{}
+
+// Ensure stores the root request trace ID on the context if it is not already set.
+func Ensure(ctx context.Context, traceID string) context.Context {
+	if ctx == nil || traceID == "" {
+		return ctx
+	}
+	if Current(ctx) != "" {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey{}, traceID)
+}
+
+// Current returns the root request trace ID stored on the context.
+func Current(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	value := ctx.Value(contextKey{})
+	if value == nil {
+		return ""
+	}
+	traceID, _ := value.(string)
+	return traceID
+}

--- a/service/operator/service.go
+++ b/service/operator/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/viant/afs"
 	"github.com/viant/afs/file"
+	"github.com/viant/datly/internal/requesttrace"
 	"github.com/viant/datly/repository"
 	rasync "github.com/viant/datly/repository/async"
 	"github.com/viant/datly/repository/content"
@@ -262,6 +263,7 @@ func (s *Service) EnsureContext(ctx context.Context, aSession *session.Session, 
 	} else {
 		info = infoValue.(*exec.Context)
 	}
+	ctx = requesttrace.Ensure(ctx, info.TraceID)
 	provider := ctx.Value(hstate.DBProviderKey)
 	if provider == nil {
 		if aView := aComponent.View; aView != nil {

--- a/service/reader/service.go
+++ b/service/reader/service.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/google/uuid"
+	"github.com/viant/datly/internal/requesttrace"
 	"github.com/viant/datly/service/executor/expand"
 	"github.com/viant/datly/shared"
 	"github.com/viant/datly/view"
@@ -96,12 +97,24 @@ func (s *Service) afterRead(ctx context.Context, aSession *Session, collector *v
 		Rows:       collector.Len(),
 	}
 	aSession.AddMetric(metrics)
+	status := Success
 	if err != nil {
-		aSession.View.Counter.IncrementValue(Error)
-	} else {
-		aSession.View.Counter.IncrementValue(Success)
+		status = Error
 	}
-	onFinish(end)
+	statusText := "ok"
+	if err != nil {
+		statusText = "error"
+	}
+	onFinish(end, status)
+	if aSession.DryRun {
+		aSession.View.Counter.IncrementValue(status)
+	}
+	fmt.Printf("[INFO] datly view read reqTraceId=%s view=%s rows=%d elapsed=%s status=%s\n",
+		reqTraceID(ctx),
+		viewName,
+		collector.Len(),
+		elapsed,
+		statusText)
 	if value := ctx.Value(exec.ContextKey); value != nil {
 		if exeCtx := value.(*exec.Context); exeCtx != nil {
 			exeCtx.AppendMetrics(metrics)
@@ -363,7 +376,7 @@ func (s *Service) querySummary(ctx context.Context, session *Session, aView *vie
 	}
 	finished := Now()
 	aView.Logger.Log("reading view %v meta took %v, SQL: %v , Args: %v\n", aView.Name, finished.Sub(now).String(), SQL, args)
-	logCacheRead(aView, cacheStats, finished.Sub(now), collector.Len(), args)
+	logCacheRead(ctx, aView, cacheStats, finished.Sub(now), collector.Len(), args)
 	return execInfo, nil
 }
 
@@ -754,7 +767,7 @@ BEGIN:
 	end := time.Now()
 
 	aView.Logger.ReadingData(end.Sub(begin), parametrizedSQL.SQL, *readData, parametrizedSQL.Args, err)
-	logCacheRead(aView, cacheStats, end.Sub(begin), *readData, parametrizedSQL.Args)
+	logCacheRead(ctx, aView, cacheStats, end.Sub(begin), *readData, parametrizedSQL.Args)
 	if err != nil {
 		stats.SetError(err)
 		anExec, err := s.HandleSQLError(err, session, aView, parametrizedSQL, stats)
@@ -868,12 +881,13 @@ func (s *Service) HandleSQLError(err error, session *Session, aView *view.View, 
 	return stats, fmt.Errorf("database error occured while fetching Data for view %v %w", aView.Name, err)
 }
 
-func logCacheRead(aView *view.View, stats *cache.Stats, elapsed time.Duration, rows int, args []interface{}) {
+func logCacheRead(ctx context.Context, aView *view.View, stats *cache.Stats, elapsed time.Duration, rows int, args []interface{}) {
 	if stats == nil {
 		return
 	}
 	recordCacheReadMetrics(aView, stats)
-	fmt.Printf("[INFO] datly cache read view=%s source=%s type=%s found_warmup=%t found_lazy=%t records=%d rows=%d namespace=%s set=%s elapsed=%s args=%v\n",
+	fmt.Printf("[INFO] datly cache read reqTraceId=%s view=%s source=%s type=%s found_warmup=%t found_lazy=%t records=%d rows=%d namespace=%s set=%s elapsed=%s args=%v\n",
+		reqTraceID(ctx),
 		aView.Name,
 		cacheReadSource(stats),
 		stats.Type,
@@ -885,6 +899,13 @@ func logCacheRead(aView *view.View, stats *cache.Stats, elapsed time.Duration, r
 		stats.Dataset,
 		elapsed,
 		args)
+}
+
+func reqTraceID(ctx context.Context) string {
+	if traceID := requesttrace.Current(ctx); traceID != "" {
+		return traceID
+	}
+	return "unknown"
 }
 
 func recordCacheReadMetrics(aView *view.View, stats *cache.Stats) {

--- a/service/reader/service_metrics_test.go
+++ b/service/reader/service_metrics_test.go
@@ -1,14 +1,19 @@
 package reader
 
 import (
+	"context"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/viant/datly/internal/requesttrace"
 	"github.com/viant/datly/logger"
 	"github.com/viant/datly/view"
+	"github.com/viant/datly/view/state"
 	"github.com/viant/gmetric/counter"
 	"github.com/viant/sqlx/io/read/cache"
+	"github.com/viant/xunsafe"
 )
 
 type metricsTestCounter struct {
@@ -20,7 +25,12 @@ func newMetricsTestCounter() *metricsTestCounter {
 }
 
 func (c *metricsTestCounter) Begin(started time.Time) counter.OnDone {
-	return func(time.Time, ...interface{}) int64 { return 0 }
+	return func(_ time.Time, values ...interface{}) int64 {
+		for _, value := range values {
+			c.values[value]++
+		}
+		return 0
+	}
 }
 
 func (c *metricsTestCounter) DecrementValue(value interface{}) int64 {
@@ -87,4 +97,55 @@ func TestRecordCacheReadMetrics(t *testing.T) {
 		}
 		require.Lenf(t, counter.values, len(testCase.expected), testCase.description)
 	}
+}
+
+type metricsTestRow struct {
+	ID int
+}
+
+func TestAfterReadRecordsLifecycleStatusViaOnFinish(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		dryRun   bool
+		expected interface{}
+	}{
+		{name: "success", expected: Success},
+		{name: "error", err: context.Canceled, expected: Error},
+		{name: "dry run success", dryRun: true, expected: Success},
+		{name: "dry run error", dryRun: true, err: context.Canceled, expected: Error},
+	}
+
+	for _, testCase := range testCases {
+		counter := newMetricsTestCounter()
+		aView := &view.View{
+			Name:    "signalPerformance",
+			Schema:  state.NewSchema(reflect.TypeOf(&metricsTestRow{})),
+			Counter: logger.NewCounter(counter),
+		}
+		dest := make([]*metricsTestRow, 0)
+		collector := view.NewCollector(xunsafe.NewSlice(reflect.TypeOf(dest)), aView, &dest, nil, false)
+		session := &Session{View: aView, DryRun: testCase.dryRun}
+
+		onFinish := aView.Counter.Begin(time.Now())
+		if testCase.dryRun {
+			onFinish = nopCounterDone
+		}
+		(&Service{}).afterRead(context.Background(), session, collector, ptrTime(time.Now().Add(-time.Millisecond)), nil, testCase.err, onFinish)
+
+		require.Equal(t, 1, counter.values[testCase.expected], testCase.name)
+	}
+}
+
+func ptrTime(value time.Time) *time.Time {
+	return &value
+}
+
+func TestReqTraceID(t *testing.T) {
+	require.Equal(t, "unknown", reqTraceID(nil))
+	require.Equal(t, "unknown", reqTraceID(context.Background()))
+
+	ctx := requesttrace.Ensure(context.Background(), "trace-123")
+
+	require.Equal(t, "trace-123", reqTraceID(ctx))
 }

--- a/view/view.go
+++ b/view/view.go
@@ -13,6 +13,7 @@ import (
 	"github.com/viant/afs/url"
 	"github.com/viant/datly/gateway/router/marshal"
 	"github.com/viant/datly/internal/setter"
+	"github.com/viant/datly/internal/gmetricx"
 	"github.com/viant/datly/logger"
 	expand2 "github.com/viant/datly/service/executor/expand"
 	"github.com/viant/datly/shared"
@@ -22,7 +23,7 @@ import (
 	"github.com/viant/datly/view/keywords"
 	"github.com/viant/datly/view/state"
 	"github.com/viant/datly/view/tags"
-	"github.com/viant/gmetric/provider"
+	"github.com/viant/gmetric"
 	"github.com/viant/sqlx"
 	"github.com/viant/sqlx/io"
 	"github.com/viant/structology"
@@ -853,7 +854,6 @@ func (v *View) ensureCounter() {
 	if v.Counter != nil {
 		return
 	}
-	var counter logger.Counter
 	if metric := v._resource.Metrics; metric != nil {
 		name := v.Name
 
@@ -863,16 +863,12 @@ func (v *View) ensureCounter() {
 			metricName = metric.Method + ":" + metricName
 		}
 		metricName = strings.ReplaceAll(metricName, "/", ".")
-		cnt := metric.Service.LookupOperation(metricName)
-
-		if cnt == nil {
-			counter = metric.Service.MultiOperationCounter(pkg, metricName, name+" performance", time.Millisecond, time.Minute, 2, provider.NewBasic())
-		} else {
-			counter = cnt
-		}
+		v.Counter = logger.NewCounter(gmetricx.NewCounter(metric.Service, metricName, func() *gmetric.Operation {
+			return metric.Service.MultiOperationCounter(pkg, metricName, name+" performance", time.Millisecond, time.Minute, 2, newViewMetricProvider())
+		}))
+		return
 	}
-
-	v.Counter = logger.NewCounter(counter)
+	v.Counter = logger.NewCounter(nil)
 
 }
 

--- a/view/view_metric_provider.go
+++ b/view/view_metric_provider.go
@@ -1,0 +1,94 @@
+package view
+
+import (
+	"reflect"
+
+	"github.com/viant/gmetric/counter"
+	"github.com/viant/gmetric/stat"
+)
+
+const (
+	successMetric        = "Success"
+	errorMetric          = "Error"
+	pendingMetric        = "Pending"
+	cacheHitMetric       = "cache:hit"
+	cacheWarmupHitMetric = "cache:warmup_hit"
+	cacheLazyHitMetric   = "cache:lazy_hit"
+	cacheMissMetric      = "cache:miss"
+	cacheMissWriteMetric = "cache:miss_write"
+	cacheErrorMetric     = "cache:error"
+)
+
+type viewMetricProvider struct{}
+
+var viewMetricKeys = []string{
+	successMetric,
+	errorMetric,
+	pendingMetric,
+	stat.ErrorKey,
+	stat.Pending,
+	cacheHitMetric,
+	cacheWarmupHitMetric,
+	cacheLazyHitMetric,
+	cacheMissMetric,
+	cacheMissWriteMetric,
+	cacheErrorMetric,
+}
+
+func newViewMetricProvider() counter.Provider {
+	return &viewMetricProvider{}
+}
+
+func (p *viewMetricProvider) Keys() []string {
+	return viewMetricKeys
+}
+
+func (p *viewMetricProvider) Map(value interface{}) int {
+	if value == nil {
+		return -1
+	}
+	if _, ok := value.(error); ok {
+		return 1
+	}
+	text, ok := metricText(value)
+	if !ok {
+		return -1
+	}
+	switch text {
+	case successMetric:
+		return 0
+	case errorMetric:
+		return 1
+	case pendingMetric:
+		return 2
+	case stat.ErrorKey:
+		return 3
+	case stat.Pending:
+		return 4
+	case cacheHitMetric:
+		return 5
+	case cacheWarmupHitMetric:
+		return 6
+	case cacheLazyHitMetric:
+		return 7
+	case cacheMissMetric:
+		return 8
+	case cacheMissWriteMetric:
+		return 9
+	case cacheErrorMetric:
+		return 10
+	default:
+		return -1
+	}
+}
+
+func metricText(value interface{}) (string, bool) {
+	if text, ok := value.(string); ok {
+		return text, true
+	}
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() || rv.Kind() != reflect.String {
+		return "", false
+	}
+	return rv.String(), true
+}

--- a/view/view_metric_provider_test.go
+++ b/view/view_metric_provider_test.go
@@ -1,0 +1,44 @@
+package view
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/viant/gmetric"
+)
+
+type namedMetric string
+
+func TestViewMetricProvider_ExportsViewCounters(t *testing.T) {
+	metrics := gmetric.New()
+	counter := metrics.MultiOperationCounter("steward/metadata", "steward.metadata.softIneligibilities", "softIneligibilities performance", time.Millisecond, time.Minute, 2, newViewMetricProvider())
+
+	counter.IncrementValue(namedMetric(successMetric))
+	counter.IncrementValue(namedMetric(errorMetric))
+	counter.IncrementValue(namedMetric(pendingMetric))
+	counter.IncrementValue(cacheHitMetric)
+	counter.IncrementValue(cacheWarmupHitMetric)
+	counter.IncrementValue(cacheLazyHitMetric)
+	counter.IncrementValue(cacheMissMetric)
+	counter.IncrementValue(cacheMissWriteMetric)
+	counter.IncrementValue(cacheErrorMetric)
+
+	operation := metrics.LookupOperation("steward.metadata.softIneligibilities")
+	require.NotNil(t, operation)
+
+	values := map[string]int64{}
+	for _, item := range operation.Counters {
+		values[item.Value] = item.Count
+	}
+
+	require.Equal(t, int64(1), values[successMetric])
+	require.Equal(t, int64(1), values[errorMetric])
+	require.Equal(t, int64(1), values[pendingMetric])
+	require.Equal(t, int64(1), values[cacheHitMetric])
+	require.Equal(t, int64(1), values[cacheWarmupHitMetric])
+	require.Equal(t, int64(1), values[cacheLazyHitMetric])
+	require.Equal(t, int64(1), values[cacheMissMetric])
+	require.Equal(t, int64(1), values[cacheMissWriteMetric])
+	require.Equal(t, int64(1), values[cacheErrorMetric])
+}


### PR DESCRIPTION
 Expose global metrics and make request/view logging joinable.

  - add global metric routes under Meta.MetricURI
  - export view and route cache/lifecycle counters through gmetric
  - harden metric counter reuse against stale gmetric operation pointers
  - add reqTraceId to reader cache-read and per-view completion logs for request correlation
