### PR TITLE
docs: fix tabjson separator typo

### DIFF
--- a/gateway/router/marshal/tabjson/reader.go
+++ b/gateway/router/marshal/tabjson/reader.go
@@ -108,7 +108,7 @@ func WriteObject(writer *Buffer, config *Config, values []string, wasString []bo
 
 	for j := 0; j < len(values); j++ {
 		if j != 0 {
-			writer.writeString(config.FieldSeparator) //TODO MFI field separtator always
+			writer.writeString(config.FieldSeparator) //TODO MFI field separator always
 		}
 
 		asString := EscapeSpecialChars(values[j], config) //TODO MFI escaping


### PR DESCRIPTION
## Summary
- Fix a typo in a tabjson reader comment: `separtator` -> `separator`.
## Verification
- Checked the target file locally to confirm the old misspelling is gone and the intended wording is present.
- - Final diff contains only this comment spelling correction.